### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Yeah
+# Yeah [![Inline docs](http://inch-ci.org/github/yeahrb/yeah.svg?branch=master)](http://inch-ci.org/github/yeahrb/yeah)
 
 Practical Ruby video game framework, alpha stage
 


### PR DESCRIPTION
Hi there,

this patch adds a docs badge to the README to show off inline-documentation to potential contributors: [![Inline docs](http://inch-ci.org/github/yeahrb/yeah.png)](http://inch-ci.org/github/yeahrb/yeah)

The badge links to [Inch CI](http://inch-ci.org), a project that tries to raise the visibility of inline-docs to encourage aspiring Rubyists to document their code. I recognize that you are not big on badges, but this could really inspire people à la "Look, this game engine has good inline-docs. Your open source game/project should too."

What do you think?
