### PR TITLE
Add benchmarking task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,3 +18,7 @@ namespace :web do
     Yeah::Web::Server.new.start
   end
 end
+
+Dir.glob(File.dirname(__FILE__) + '/tasks/*.rb').each do |file|
+  load file
+end

--- a/tasks/benchmark.rb
+++ b/tasks/benchmark.rb
@@ -1,0 +1,63 @@
+require 'benchmark'
+
+namespace :benchmark do
+  task :setup do
+    ENV['ITERATIONS'] ||= '100000'
+  end
+
+  desc 'Benchmark Yeah::Vector'
+  task :vector => :setup do |task|
+    require 'yeah/vector'
+    Benchmark.bm(10) do |bm|
+      iterations = ENV['ITERATIONS'].to_i
+
+      a = Yeah::Vector.new(10, 20, 30)
+      b = Yeah::Vector.new(-5, -5, -5)
+
+      bm.report('+') do
+        iterations.times { |i| a + b }
+      end
+
+      bm.report('-') do
+        iterations.times { |i| a - b }
+      end
+
+      bm.report('*') do
+        iterations.times { |i| a * 5 }
+      end
+
+      bm.report('/') do
+        iterations.times { |i| a / 5 }
+      end
+
+      bm.report('+@') do
+        iterations.times { |i| +a }
+      end
+
+      bm.report('-@') do
+        iterations.times { |i| -a }
+      end
+
+      bm.report('length') do
+        iterations.times { |i| a.length }
+      end
+
+      bm.report('distance_to') do
+        iterations.times { |i| a.distance_to(b) }
+      end
+
+      bm.report('angle_to') do
+        iterations.times { |i| a.angle_to(b) }
+      end
+
+      radian = Math::PI * 45 / 180
+      bm.report('along') do
+        iterations.times { |i| a.along(radian, 10) }
+      end
+
+      bm.report('along!') do
+        iterations.times { |i| a.along!(radian, 10) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add benchmarking task. (ref. #12)

`rake benchmark:vector` to benchmark `Yeah::Vector`.

``` sh
$ rake --tasks
rake benchmark:vector  # Benchmark Yeah::Vector
rake web:test          # Run tests through opal-minitest
$ rake benchmark:vector
                 user     system      total        real
+            0.080000   0.000000   0.080000 (  0.077147)
-            0.080000   0.000000   0.080000 (  0.081059)
*            0.070000   0.000000   0.070000 (  0.071861)
/            0.080000   0.000000   0.080000 (  0.076522)
+@           0.060000   0.000000   0.060000 (  0.065507)
-@           0.100000   0.000000   0.100000 (  0.100169)
length       0.060000   0.000000   0.060000 (  0.051005)
distance_to  0.100000   0.000000   0.100000 (  0.108767)
angle_to     0.150000   0.000000   0.150000 (  0.147239)
along        0.110000   0.000000   0.110000 (  0.109092)
along!       0.070000   0.000000   0.070000 (  0.070629)
```

Iterations are able to set via environment variable (default: 100,000).

``` sh
$ ITERATIONS=1_000_000 rake benchmark:vector
                 user     system      total        real
+            0.710000   0.000000   0.710000 (  0.714035)
-            0.730000   0.000000   0.730000 (  0.725722)
*            0.680000   0.000000   0.680000 (  0.682436)
/            0.680000   0.000000   0.680000 (  0.687387)
+@           0.600000   0.000000   0.600000 (  0.597083)
-@           1.000000   0.000000   1.000000 (  1.003476)
length       0.520000   0.000000   0.520000 (  0.517457)
distance_to  1.050000   0.000000   1.050000 (  1.051363)
angle_to     1.420000   0.010000   1.430000 (  1.424797)
along        1.040000   0.000000   1.040000 (  1.043859)
along!       0.650000   0.000000   0.650000 (  0.653981)
```

yeah?
