### PR TITLE
Simplify unary negation operator

### DIFF
--- a/lib/yeah/vector.rb
+++ b/lib/yeah/vector.rb
@@ -113,7 +113,9 @@ class Vector
 
   # @return [Vector] negative vector
   def -@
-    self.class.new(*@components.map(&:-@))
+    self.class.new(-@components[0],
+                   -@components[1],
+                   -@components[2])
   end
 
   # @param [Vector] position


### PR DESCRIPTION
this commit improves `Yeah::Vector#-@`. 
it is forgotten in b48445786966e75c53c13afd258f852fa78ba56d.

Benchmark(#24) results are as follows.

``` sh
$ rake benchmark:vector
                 user     system      total        real
+            0.080000   0.000000   0.080000 (  0.079335)
-            0.080000   0.000000   0.080000 (  0.072993)
*            0.070000   0.000000   0.070000 (  0.069291)
/            0.070000   0.000000   0.070000 (  0.071865)
+@           0.060000   0.000000   0.060000 (  0.068067)
-@           0.080000   0.000000   0.080000 (  0.072928)  # <-
length       0.050000   0.000000   0.050000 (  0.052774)
distance_to  0.110000   0.000000   0.110000 (  0.111375)
angle_to     0.160000   0.000000   0.160000 (  0.156575)
along        0.110000   0.000000   0.110000 (  0.111847)
along!       0.060000   0.000000   0.060000 (  0.068772)
```
