### PR TITLE
Added runtime dependency of Opal

### DIFF
--- a/yeah.gemspec
+++ b/yeah.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/yeahrb/yeah'
   s.license = 'MIT'
 
+  s.add_runtime_dependency 'opal', '~> 0.6.2'
+
   s.add_development_dependency 'rake', '~> 10.3.1'
   s.add_development_dependency 'minitest', '~> 5.3.2'
   s.add_development_dependency 'opal-minitest', '~> 0.0.4'


### PR DESCRIPTION
I can't install yeah without installing opal.
Do we need runtime dependency?

Thank you for nice product!
